### PR TITLE
Connect to 2.4 Ghz channels above 11

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -255,7 +255,7 @@ gVhtRxMCS=2
 gVhtTxMCS=2
 
 # Enable CRDA regulatory support by settings default country code
-#gCrdaDefaultCountryCode=TW
+gCrdaDefaultCountryCode=UK
 
 # Scan Timing Parameters
 # gPassiveMaxChannelTime=110


### PR DESCRIPTION
This little modification will allow the tablet to connect to access points on channels over 11. I tested it extensively on MarshMallow and now on Nougat Roms.
